### PR TITLE
Update dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,8 +692,7 @@ dependencies = [
 [[package]]
 name = "duckdb"
 version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ab83a22530667ffc8cc0e31c0549bb07bea5dba3b957a8e315effc38923701"
+source = "git+https://github.com/duckdb/duckdb-rs#4a6486879dc4cc1b8c87abc06e754633c3a429c7"
 dependencies = [
  "arrow",
  "cast",
@@ -711,8 +710,7 @@ dependencies = [
 [[package]]
 name = "duckdb-loadable-macros"
 version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00616e16f5e8b6453a57593b1e7c1cb7f5b3208533218ba10036108fa9d5acd3"
+source = "git+https://github.com/duckdb/duckdb-rs#4a6486879dc4cc1b8c87abc06e754633c3a429c7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1273,8 +1271,7 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 [[package]]
 name = "libduckdb-sys"
 version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e02f6069513efb67a0743aff3b846090de14763802b0e95c352ebc6e1bdc1da"
+source = "git+https://github.com/duckdb/duckdb-rs#4a6486879dc4cc1b8c87abc06e754633c3a429c7"
 dependencies = [
  "flate2",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,7 @@ path = "src/wasm_lib.rs"
 crate-type = ["staticlib"]
 
 [dependencies]
-duckdb = { version = "1.3.2", features = [
-    "vscalar",
-    "vscalar-arrow",
-    "vtab-arrow",
-] }
-duckdb-loadable-macros = "0.1.9"
-libduckdb-sys = { version = "1.3.0", features = ["loadable-extension"] }
+duckdb = { version = "1.3.2", git = "https://github.com/duckdb/duckdb-rs", features = ["vscalar"] }
+duckdb-loadable-macros = { version = "*", git = "https://github.com/duckdb/duckdb-rs" }
+libduckdb-sys = { version = "1.3.2", git = "https://github.com/duckdb/duckdb-rs", features = ["loadable-extension"] }
 rfd = "0.15.3"


### PR DESCRIPTION
Note that, this doesn't change the dependency. It's just that `vscalar` feature now depends on `vtab-arrow` explicitly.